### PR TITLE
FIX: Remove "implicit any" compiler warnings

### DIFF
--- a/waterline/waterline.d.ts
+++ b/waterline/waterline.d.ts
@@ -148,10 +148,11 @@ declare module waterline {
         toObject(): Object;
         save(options: {}, cb: cb): any;
         destory(cb: any): any;
+        find(query: Object): any;
         _defineAssociations(): void;
         _normalizeAssociations(): void;
         _cast(values: any[]): void;
-        query(query: string, cb: cb): void; 
+        query(query: string, cb: cb): void;
         validate(cb: cb): void | any;
         toJSON(): JSON;
     }

--- a/waterline/waterline.d.ts
+++ b/waterline/waterline.d.ts
@@ -98,7 +98,7 @@ declare module waterline {
         update(criteria: {}, values: {}, cb?: cb): any;
         destroy(criteria: {}, cb?: cb): any;
         count(criteria: {}, options: {}, cb?: cb): any;
-        join(collection, fk, pk, cb): void;
+        join(collection: any, fk: any, pk: any, cb: cb): void;
     }
 
     export interface aggregate {
@@ -147,7 +147,7 @@ declare module waterline {
         (context: {}, mixins: {}): Model;
         toObject(): Object;
         save(options: {}, cb: cb): any;
-        destory(cb): any;
+        destory(cb: any): any;
         _defineAssociations(): void;
         _normalizeAssociations(): void;
         _cast(values: any[]): void;

--- a/waterline/waterline.d.ts
+++ b/waterline/waterline.d.ts
@@ -151,6 +151,7 @@ declare module waterline {
         _defineAssociations(): void;
         _normalizeAssociations(): void;
         _cast(values: any[]): void;
+        query(query: string, cb: cb): void; 
         validate(cb: cb): void | any;
         toJSON(): JSON;
     }


### PR DESCRIPTION
I have `"noImplicitAny": true,` set in my tsconfig.json for a project I'm working on and was getting compiler warnings. This explicitly sets the following fields to the `any` type. Thanks for the spent you've spent on this so far!
